### PR TITLE
Support for output of the .vec format

### DIFF
--- a/wvlib.py
+++ b/wvlib.py
@@ -165,7 +165,7 @@ NUMPY_FORMAT = 'npy'
 TSV_FORMAT = 'tsv'
 
 formats = sorted(list(set(extension_format_map.values())))
-output_formats = sorted([WVLIB_FORMAT, WORD2VEC_BIN, SDV_FORMAT])
+output_formats = sorted([WVLIB_FORMAT, WORD2VEC_BIN, SDV_FORMAT, WORD2VEC_TEXT])
 vector_formats = sorted([NUMPY_FORMAT, TSV_FORMAT])
 
 class FormatError(Exception):
@@ -455,6 +455,8 @@ class WVData(object):
                 return self.save_bin(name)
             elif format == SDV_FORMAT:
                 return self.save_sdv(name)
+            elif format == WORD2VEC_TEXT:
+                return self.save_w2v_text(name)
             else:
                 raise NotImplementedError
         finally:
@@ -519,6 +521,14 @@ class WVData(object):
         with open(name, 'wt') as f:
             for w, v in self:
                 print >> f, w, ' '.join(str(i) for i in v)
+
+    def save_w2v_text(self, name, numformat=".6f"):
+        """ Use "g" for a general number format - this can produce 1e-17. Use ".6f" for 0.XXXXXX """
+        words, vectors = self.words(), self.vectors()
+        with open(name, 'wt') as f:
+            print >> f, "%d %d"%(len(vectors),len(vectors[0]))
+            for w, v in self:
+                print >> f, w, ' '.join(("{:"+numformat+"}").format(i) for i in v)
 
     def _invalidate(self):
         """Invalidate cached values."""


### PR DESCRIPTION
A little blob which will allow you to save the .vec format. I did not figure how to make it play with convert.py (could not understand the difference between format and vector_format), but anyway, this does something.

In particular, some downstream uses (and maybe word2vec itself) cannot produce/understand the exponential notation. So the function has a parameter for that. Maybe these should be two formats?